### PR TITLE
Fixing a bug in client

### DIFF
--- a/client.js
+++ b/client.js
@@ -40,7 +40,7 @@ socket.on('message', function (data) {
   var subr = 'r/' + data.subreddit;
   var text = data.body.replace(/\s/g, ' ');
 
-  var formatted = date + ": by " + user + ' in ' + subr + ': ' + text;
+  var message = date + ": by " + user + ' in ' + subr + ': ' + text;
   var maxLength = 120;
 
   // Truncate if required so that it fits nicely in a terminal window.


### PR DESCRIPTION
Tried to run the demo client, got an error message that the `message` variable didn't exist. Turns out you named it `formatted` instead of `message` when you declared it (I guess?).
